### PR TITLE
fix: update contributor UI

### DIFF
--- a/core/file-service/src/main/scala/edu/uci/ics/texera/service/resource/DatasetResource.scala
+++ b/core/file-service/src/main/scala/edu/uci/ics/texera/service/resource/DatasetResource.scala
@@ -161,8 +161,8 @@ object DatasetResource {
   }
 
   /**
-   * Helper function to get the contributors using the did
-   */
+    * Helper function to get the contributors using the did
+    */
   def getContributorsByDid(did: Integer): List[Contributor] = {
     val ctx = SqlServer.getInstance().createDSLContext()
     val dao = new DatasetContributorDao(ctx.configuration())
@@ -183,7 +183,7 @@ object DatasetResource {
       accessPrivilege: EnumType,
       isOwner: Boolean,
       size: Long,
-      contributors: Option[List[Contributor]] = Some(Nil),
+      contributors: Option[List[Contributor]] = Some(Nil)
   )
 
   case class DashboardDatasetVersion(
@@ -195,7 +195,7 @@ object DatasetResource {
       datasetName: String,
       datasetDescription: String,
       isDatasetPublic: Boolean,
-      contributors: Option[List[Contributor]],
+      contributors: Option[List[Contributor]]
   )
 
   case class Diff(
@@ -213,11 +213,11 @@ object DatasetResource {
   )
 
   case class Contributor(
-    name: String,
-    creator: Boolean,
-    role: String,
-    affiliation: String,
-    email: String
+      name: String,
+      creator: Boolean,
+      role: String,
+      affiliation: String,
+      email: String
   )
 
 }
@@ -259,7 +259,7 @@ class DatasetResource {
       userAccessPrivilege,
       isOwner,
       LakeFSStorageClient.retrieveRepositorySize(targetDataset.getName),
-      contributors = Some(contributors),
+      contributors = Some(contributors)
     )
   }
 
@@ -325,7 +325,6 @@ class DatasetResource {
         datasetContributorDao.insert(datasetContributor)
       }
 
-
       // Insert the requester as the WRITE access user for this dataset
       val datasetUserAccess = new DatasetUserAccess()
       datasetUserAccess.setDid(createdDataset.getDid)
@@ -346,7 +345,7 @@ class DatasetResource {
         PrivilegeEnum.WRITE,
         isOwner = true,
         0,
-        contributors,
+        contributors
       )
     }
   }
@@ -1251,15 +1250,15 @@ class DatasetResource {
       DatasetFileNode.calculateTotalSize(List(ownerFileNode))
     )
   }
-    @PUT
-    @Path("/{did}/contributors")
-    @RolesAllowed(Array("REGULAR", "ADMIN"))
-    @Consumes(Array(MediaType.APPLICATION_JSON))
-    def updateDatasetContributors(
-                                 @PathParam("did") did: Int,
-                                 request: java.util.Map[String, java.util.List[DatasetResource.Contributor]],
-                                 @Auth user: SessionUser
-                               ): Response = {
+  @PUT
+  @Path("/{did}/contributors")
+  @RolesAllowed(Array("REGULAR", "ADMIN"))
+  @Consumes(Array(MediaType.APPLICATION_JSON))
+  def updateDatasetContributors(
+      @PathParam("did") did: Int,
+      request: java.util.Map[String, java.util.List[DatasetResource.Contributor]],
+      @Auth user: SessionUser
+  ): Response = {
     withTransaction(context) { ctx =>
       val datasetContributorDao = new DatasetContributorDao(ctx.configuration())
 
@@ -1269,10 +1268,10 @@ class DatasetResource {
       }
 
       // Delete existing contributors for this dataset
-      ctx.delete(DATASET_CONTRIBUTOR)
+      ctx
+        .delete(DATASET_CONTRIBUTOR)
         .where(DATASET_CONTRIBUTOR.DID.eq(did))
         .execute()
-
 
       // Re-insert updated contributors
       contributors.asScala.foreach { contributor: DatasetResource.Contributor =>

--- a/core/gui/src/app/app.module.ts
+++ b/core/gui/src/app/app.module.ts
@@ -139,7 +139,7 @@ import { UserDatasetVersionCreatorComponent } from "./dashboard/component/user/u
 import { DatasetDetailComponent } from "./dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component";
 import { UserDatasetVersionFiletreeComponent } from "./dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component";
 import { UserDatasetFileRendererComponent } from "./dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component";
-import { UserDatasetContributorEditor } from "./dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-contributor-editor/user-dataset-contributor-editor.component";
+import { UserDatasetContributorEditorComponent } from "./dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-contributor-editor/user-dataset-contributor-editor.component";
 import { NzSpinModule } from "ng-zorro-antd/spin";
 import { UserDatasetListItemComponent } from "./dashboard/component/user/user-dataset/user-dataset-list-item/user-dataset-list-item.component";
 import { NgxFileDropModule } from "ngx-file-drop";
@@ -231,7 +231,7 @@ registerLocaleData(en);
     UserDatasetListItemComponent,
     UserDatasetFileRendererComponent,
     UserDatasetStagedObjectsListComponent,
-    UserDatasetContributorEditor,
+    UserDatasetContributorEditorComponent,
     NzModalCommentBoxComponent,
     LeftPanelComponent,
     LocalLoginComponent,

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts
@@ -43,7 +43,7 @@ import { DatasetStagedObject } from "../../../../../common/type/dataset-staged-o
 import { NzModalService } from "ng-zorro-antd/modal";
 import { UserDatasetVersionCreatorComponent } from "./user-dataset-version-creator/user-dataset-version-creator.component";
 import { DashboardDataset } from "../../../../type/dashboard-dataset.interface";
-import { UserDatasetContributorEditor } from "./user-dataset-contributor-editor/user-dataset-contributor-editor.component";
+import { UserDatasetContributorEditorComponent } from "./user-dataset-contributor-editor/user-dataset-contributor-editor.component";
 
 export const THROTTLE_TIME_MS = 1000;
 
@@ -493,11 +493,11 @@ export class DatasetDetailComponent implements OnInit {
   onAddContributor(): void {
     const modal = this.modalService.create({
       nzTitle: "Add Contributor",
-      nzContent: UserDatasetContributorEditor,
+      nzContent: UserDatasetContributorEditorComponent,
       nzFooter: null,
       nzData: null,
     });
-    modal.afterClose.subscribe(newContributor => {
+    modal.afterClose.pipe(untilDestroyed(this)).subscribe(newContributor => {
       if (newContributor) {
         this.datasetContributors = [...this.datasetContributors, newContributor];
         this.saveContributors();
@@ -509,11 +509,11 @@ export class DatasetDetailComponent implements OnInit {
   onEditContributor(contributor: any): void {
     const modal = this.modalService.create({
       nzTitle: "Edit Contributor",
-      nzContent: UserDatasetContributorEditor,
+      nzContent: UserDatasetContributorEditorComponent,
       nzFooter: null,
       nzData: { ...contributor },
     });
-    modal.afterClose.subscribe(updated => {
+    modal.afterClose.pipe(untilDestroyed(this)).subscribe(updated => {
       if (updated) {
         // replace the old contributor with updated
         this.datasetContributors = this.datasetContributors.map(c => (c.id === updated.id ? updated : c));
@@ -525,9 +525,12 @@ export class DatasetDetailComponent implements OnInit {
   /** Persist contributors to backend */
   private saveContributors(): void {
     if (!this.did) return;
-    this.datasetService.updateDatasetContributors(this.did, this.datasetContributors).subscribe({
-      next: () => this.notificationService.success("Contributors updated"),
-      error: () => this.notificationService.error("Failed to update contributors"),
-    });
+    this.datasetService
+      .updateDatasetContributors(this.did, this.datasetContributors)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: () => this.notificationService.success("Contributors updated"),
+        error: () => this.notificationService.error("Failed to update contributors"),
+      });
   }
 }

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-contributor-editor/user-dataset-contributor-editor.component.html
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-contributor-editor/user-dataset-contributor-editor.component.html
@@ -1,30 +1,44 @@
-<form
-  [formGroup]="contributorForm"
-  (ngSubmit)="submit()"
-  class="formly-form">
-  <formly-form
-    [form]="contributorForm"
-    [model]="model"
-    [fields]="fields"></formly-form>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
 
-  <nz-row>
-    <div
-      nz-col
-      nzOffset="6"
-      nzSpan="14">
-      <button
-        nzType="default"
-        (click)="cancel()"
-        style="margin-right: 8px"
-        type="button">
-        Cancel
-      </button>
-      <button
-        nzType="primary"
-        [disabled]="contributorForm.invalid"
-        type="submit">
-        Save
-      </button>
-    </div>
-  </nz-row>
-</form>
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+<div class="contributor-form">
+  <form
+    [formGroup]="contributorForm"
+    (ngSubmit)="submit()"
+    class="formly-form">
+    <formly-form
+      [form]="contributorForm"
+      [model]="model"
+      [fields]="fields"></formly-form>
+
+    <button
+      nz-button
+      nzType="primary"
+      class="save-btn">
+      Save
+    </button>
+    <button
+      nz-button
+      nzType="default"
+      (click)="cancel()"
+      class="cancel-btn">
+      Cancel
+    </button>
+  </form>
+</div>

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-contributor-editor/user-dataset-contributor-editor.component.scss
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-contributor-editor/user-dataset-contributor-editor.component.scss
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.contributor-form {
+  width: 80%;
+  margin: auto;
+}
+
+.save-btn {
+  background-color: #ffffff;
+  color: #007bff;
+  border: 1px solid lightgray;
+  padding: 5px 20px;
+  cursor: pointer;
+  margin-left: 15%;
+  margin-right: 5%;
+  width: 30%;
+  text-align: center;
+  &:hover {
+    background-color: darken(#007bff, 10%);
+    color: #ffffff;
+  }
+}
+
+.cancel-btn {
+  background-color: #ffffff;
+  color: #ff0000;
+  border: 1px solid lightgray;
+  padding: 5px 20px;
+  cursor: pointer;
+  margin-right: 15%;
+  margin-left: 5%;
+  margin-top: 5%;
+  width: 30%;
+  text-align: center;
+  &:hover {
+    background-color: darken(#ff0000, 10%);
+    color: #ffffff;
+  }
+}

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-contributor-editor/user-dataset-contributor-editor.component.ts
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-contributor-editor/user-dataset-contributor-editor.component.ts
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { Component, EventEmitter, OnInit, Output, Inject } from "@angular/core";
 import { FormGroup } from "@angular/forms";
 import { NZ_MODAL_DATA } from "ng-zorro-antd/modal";
@@ -16,6 +35,7 @@ export interface ContributorData {
 @Component({
   selector: "texera-user-dataset-contributor-editor",
   templateUrl: "./user-dataset-contributor-editor.component.html",
+  styleUrls: ["./user-dataset-contributor-editor.component.scss"],
 })
 export class UserDatasetContributorEditor implements OnInit {
   @Output() contributorChange = new EventEmitter<ContributorData>();

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-contributor-editor/user-dataset-contributor-editor.component.ts
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-contributor-editor/user-dataset-contributor-editor.component.ts
@@ -37,7 +37,7 @@ export interface ContributorData {
   templateUrl: "./user-dataset-contributor-editor.component.html",
   styleUrls: ["./user-dataset-contributor-editor.component.scss"],
 })
-export class UserDatasetContributorEditor implements OnInit {
+export class UserDatasetContributorEditorComponent implements OnInit {
   @Output() contributorChange = new EventEmitter<ContributorData>();
 
   contributorForm = new FormGroup({});

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-creator/user-dataset-version-creator.component.html
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-creator/user-dataset-version-creator.component.html
@@ -29,30 +29,32 @@
         [form]="form"
         [fields]="fields"
         [model]="model"></formly-form>
-      <nz-switch
-        *ngIf="!isCreatingVersion"
-        [ngModel]="isDatasetPublic"
-        (ngModelChange)="onPublicStatusChange($event)"
-        nzCheckedChildren="public"
-        nzUnCheckedChildren="private"></nz-switch>
     </div>
-
-    <button
-      nz-button
-      nzType="primary"
-      (click)="onClickCreate()"
-      [disabled]="isCreateButtonDisabled || isCreating"
-      class="create-btn">
-      Create
-    </button>
-
-    <button
-      nz-button
-      nzType="default"
-      (click)="onClickCancel()"
-      class="cancel-btn"
-      [disabled]="isCreating">
-      Cancel
-    </button>
+    <nz-switch
+      class="public-status"
+      *ngIf="!isCreatingVersion"
+      [ngModel]="isDatasetPublic"
+      (ngModelChange)="onPublicStatusChange($event)"
+      nzCheckedChildren="public"
+      nzUnCheckedChildren="private">
+    </nz-switch>
   </nz-spin>
+
+  <button
+    nz-button
+    nzType="primary"
+    (click)="onClickCreate()"
+    [disabled]="isCreateButtonDisabled || isCreating"
+    class="create-btn">
+    Create
+  </button>
+
+  <button
+    nz-button
+    nzType="default"
+    (click)="onClickCancel()"
+    class="cancel-btn"
+    [disabled]="isCreating">
+    Cancel
+  </button>
 </div>

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-creator/user-dataset-version-creator.component.scss
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-creator/user-dataset-version-creator.component.scss
@@ -51,7 +51,7 @@
   cursor: pointer;
   margin-right: 15%;
   margin-left: 5%;
-  margin-top: 10%;
+  margin-top: 5%;
   width: 30%;
   text-align: center;
   &:hover {
@@ -64,4 +64,8 @@
   height: 40%;
   width: 90%;
   margin: auto;
+}
+
+.public-status {
+  margin-left: 45px;
 }

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-creator/user-dataset-version-creator.component.ts
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-creator/user-dataset-version-creator.component.ts
@@ -116,6 +116,7 @@ export class UserDatasetVersionCreatorComponent implements OnInit {
                 {
                   key: "creator",
                   type: "checkbox",
+                  defaultValue: false,
                   templateOptions: {
                     label: "Creator",
                   },


### PR DESCRIPTION
### **Purpose**
This PR updates the contributor‑creation by standardizing the save and cancel button styles and the creator‑status selection component, aligning its appearance with the existing dataset‑creation UI.

### **Changes**
- app.module.ts/dataset-detail.components.ts: updated component class names to follow naming conventions
- user-dataset-contributor-editor.compoent.ts/html/scss: refactored the UI to standardize Save/Cancel buttons for consistent styling and layout
- user-dataset-version-creator.component.ts/html/scss: refactored the creator‑status selector to match the dataset‑creation flow and updated component names
- DatasetResource.scala: refactored comment to follow convention

### **Demonstration**
Adding a contributor during database creation:
| Before | After |
|:------:|:------:|
| <img src="https://github.com/user-attachments/assets/fde3344c-96d3-4f81-91aa-1cddba883494" alt="Before" width="300" /> | <img src="https://github.com/user-attachments/assets/ea222e4f-09b9-4c2b-a5ae-9c8dec17d356" alt="After" width="300" /> |

Updating a contributor after creation:
<img width="1563" height="911" alt="contributor" src="https://github.com/user-attachments/assets/f23123a0-acff-4ece-aa55-a28bef9262a4" />
| Save | Cancel |
|:----:|:------:|
| <img src="https://github.com/user-attachments/assets/947497e4-7ca3-4ec7-815e-5680d4e48b56" alt="Save" width="300" /> | <img src="https://github.com/user-attachments/assets/3bc20b3b-fee2-475b-9150-7b4f5580f0eb" alt="Cancel" width="300" /> |



