### PR TITLE
 feat: integrate MERFISHeyes visualization

### DIFF
--- a/bin/k8s/templates/gateway-routes.yaml
+++ b/bin/k8s/templates/gateway-routes.yaml
@@ -80,6 +80,15 @@ spec:
       backendRefs:
         - name: python-language-server-svc
           port: 3000
+    {{- if .Values.merfisheyes.enabled }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /merfisheyes
+      backendRefs:
+        - name: {{ .Values.merfisheyes.name }}-svc
+          port: {{ .Values.merfisheyes.service.port }}
+    {{- end }}
     - matches:
         - path:
             type: PathPrefix

--- a/bin/k8s/templates/merfisheyes-deployment.yaml
+++ b/bin/k8s/templates/merfisheyes-deployment.yaml
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{- if .Values.merfisheyes.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.merfisheyes.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-{{ .Values.merfisheyes.name }}
+spec:
+  replicas: {{ .Values.merfisheyes.numOfPods }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-{{ .Values.merfisheyes.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-{{ .Values.merfisheyes.name }}
+    spec:
+      containers:
+        - name: {{ .Values.merfisheyes.name }}
+          image: {{ .Values.merfisheyes.image }}:{{ .Values.merfisheyes.imageTag }}
+          imagePullPolicy: {{ .Values.merfisheyes.imagePullPolicy | default "IfNotPresent" }}
+          {{- if .Values.merfisheyes.command }}
+          command:
+{{ toYaml .Values.merfisheyes.command | indent 12 }}
+          {{- end }}
+          {{- if .Values.merfisheyes.args }}
+          args:
+{{ toYaml .Values.merfisheyes.args | indent 12 }}
+          {{- end }}
+          ports:
+            - containerPort: {{ .Values.merfisheyes.service.port }}
+          env:
+            - name: NODE_ENV
+              value: "production"
+          readinessProbe:
+            httpGet:
+              path: /merfisheyes/viewer
+              port: {{ .Values.merfisheyes.service.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /merfisheyes/viewer
+              port: {{ .Values.merfisheyes.service.port }}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+{{- end }}

--- a/bin/k8s/templates/merfisheyes-service.yaml
+++ b/bin/k8s/templates/merfisheyes-service.yaml
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{- if .Values.merfisheyes.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.merfisheyes.name }}-svc
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: {{ .Values.merfisheyes.service.type }}
+  selector:
+    app: {{ .Release.Name }}-{{ .Values.merfisheyes.name }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.merfisheyes.service.port }}
+      targetPort: {{ .Values.merfisheyes.service.port }}
+{{- end }}

--- a/bin/k8s/values-development.yaml
+++ b/bin/k8s/values-development.yaml
@@ -314,6 +314,17 @@ pythonLanguageServer:
       cpu: "100m"
       memory: "100Mi"
 
+merfisheyes:
+  enabled: true
+  name: merfisheyes
+  numOfPods: 1
+  image: appelpi/merfisheyes
+  imageTag: v0.1.0-microservice
+  imagePullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 3000
+
 # Metrics Server configuration
 metrics-server:
   enabled: true # set to false if metrics-server is already installed

--- a/bin/k8s/values.yaml
+++ b/bin/k8s/values.yaml
@@ -264,6 +264,17 @@ pythonLanguageServer:
       cpu: "100m"
       memory: "100Mi"
 
+merfisheyes:
+  enabled: false
+  name: merfisheyes
+  numOfPods: 1
+  image: appelpi/merfisheyes
+  imageTag: v0.1.0-microservice
+  imagePullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 3000
+
 # Metrics Server configuration
 metrics-server:
   enabled: true # set to false if metrics-server is already installed

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
@@ -311,17 +311,6 @@
               </nz-select>
               <button
                 nz-button
-                nz-tooltip="Open AAV Gallery"
-                (click)="onClickOpenAavGallery()"
-                *ngIf="selectedVersion && aavGalleryUrl"
-                class="spaced-button">
-                <i
-                  nz-icon
-                  nzType="export"
-                  nzTheme="outline"></i>
-              </button>
-              <button
-                nz-button
                 nz-tooltip="Download Dataset"
                 (click)="onClickDownloadVersionAsZip()"
                 *ngIf="selectedVersion"
@@ -330,6 +319,19 @@
                 <i
                   nz-icon
                   nzType="download"
+                  nzTheme="outline"></i>
+              </button>
+              <button
+                nz-button
+                nz-tooltip
+                [nzTooltipTitle]="visualizationLaunchTooltip"
+                (click)="onClickOpenAutoVisualization()"
+                *ngIf="selectedVersion"
+                [disabled]="!hasAutoVisualizationTarget"
+                class="spaced-button">
+                <i
+                  nz-icon
+                  nzType="dot-chart"
                   nzTheme="outline"></i>
               </button>
             </div>

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts
@@ -51,6 +51,13 @@ export const THROTTLE_TIME_MS = 1000;
 export const ABORT_RETRY_MAX_ATTEMPTS = 10;
 export const ABORT_RETRY_BACKOFF_BASE_MS = 100;
 
+type MerfisheyesMode = "single_cell" | "single_molecule";
+interface MerfisheyesLayout {
+  datasetRoot: string;
+  hasSingleCell: boolean;
+  hasSingleMolecule: boolean;
+}
+
 @UntilDestroy()
 @Component({
   templateUrl: "./dataset-detail.component.html",
@@ -91,6 +98,12 @@ export class DatasetDetailComponent implements OnInit {
 
   public datasetContributors: any[] = [];
   public aavGalleryUrl: string = "";
+  public autoVisualizationUrl: string = "";
+  public visualizationLaunchTooltip: string = "No compatible visualization layout found.";
+
+  public get hasAutoVisualizationTarget(): boolean {
+    return !!this.autoVisualizationUrl;
+  }
 
   userHasPendingChanges: boolean = false;
   pendingChangesCount: number = 0;
@@ -369,6 +382,7 @@ export class DatasetDetailComponent implements OnInit {
           }
           this.loadFileContent(currentNode);
           this.updateAavGalleryUrl();
+          this.refreshVisualizationAvailabilityAndSelection();
         });
   }
 
@@ -808,12 +822,71 @@ export class DatasetDetailComponent implements OnInit {
       });
   }
 
-  onClickOpenAavGallery(): void {
-    if (!this.aavGalleryUrl) {
-      this.notificationService.warning("AAV gallery is unavailable for this dataset version.");
+  onClickOpenAutoVisualization(): void {
+    if (!this.autoVisualizationUrl) {
+      this.notificationService.warning(this.visualizationLaunchTooltip);
       return;
     }
-    window.open(this.aavGalleryUrl, "_blank", "noopener,noreferrer");
+    window.open(this.autoVisualizationUrl, "_blank", "noopener,noreferrer");
+  }
+
+  private refreshVisualizationAvailabilityAndSelection(): void {
+    const layout = this.findMerfisheyesLayout(this.fileTreeNodeList);
+    if (layout?.hasSingleCell) {
+      this.autoVisualizationUrl = this.buildMerfisheyesUrl("single_cell", layout.datasetRoot);
+      this.visualizationLaunchTooltip = "Open MERFISHEYES Single Cell";
+    } else if (layout?.hasSingleMolecule) {
+      this.autoVisualizationUrl = this.buildMerfisheyesUrl("single_molecule", layout.datasetRoot);
+      this.visualizationLaunchTooltip = "Open MERFISHEYES Single Molecule";
+    } else if (this.aavGalleryUrl) {
+      this.autoVisualizationUrl = this.aavGalleryUrl;
+      this.visualizationLaunchTooltip = "Open AAV Gallery";
+    } else {
+      this.autoVisualizationUrl = "";
+      this.visualizationLaunchTooltip = "No compatible visualization layout found.";
+    }
+  }
+
+  private buildMerfisheyesUrl(mode: MerfisheyesMode, datasetRoot: string): string {
+    if (!this.ownerEmail || !this.datasetName || !this.selectedVersion?.name) {
+      return "";
+    }
+    const route = mode === "single_molecule" ? "/merfisheyes/sm-viewer/from-s3" : "/merfisheyes/viewer/from-s3";
+    const params = new URLSearchParams({
+      owner: this.ownerEmail,
+      dataset: this.datasetName,
+      version: this.selectedVersion.name,
+    });
+    if (datasetRoot) {
+      params.set("datasetRoot", datasetRoot);
+    }
+    return `${route}?${params.toString()}`;
+  }
+
+  private findMerfisheyesLayout(
+    nodes: ReadonlyArray<DatasetFileNode>,
+    datasetRoot: string = ""
+  ): MerfisheyesLayout | null {
+    const hasDir = (name: string) => nodes.some(n => n.type === "directory" && n.name === name);
+    const hasFile = (name: string) => nodes.some(n => n.type === "file" && n.name === name);
+    const hasManifest = hasFile("manifest.json") || hasFile("manifest.json.gz");
+    const hasSingleCell = hasManifest && hasDir("expr") && hasDir("obs") && hasDir("coords");
+    const hasSingleMolecule = hasManifest && hasDir("genes");
+
+    if (hasSingleCell || hasSingleMolecule) {
+      return { datasetRoot, hasSingleCell, hasSingleMolecule };
+    }
+
+    for (const node of nodes) {
+      if (node.type === "directory" && node.children?.length) {
+        const childRoot = datasetRoot ? `${datasetRoot}/${node.name}` : node.name;
+        const nested = this.findMerfisheyesLayout(node.children, childRoot);
+        if (nested) {
+          return nested;
+        }
+      }
+    }
+    return null;
   }
 
   private updateAavGalleryUrl(): void {


### PR DESCRIPTION
<!--
Thanks for sending a pull request (PR)! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 
     [Contributing to Texera](https://github.com/apache/texera/blob/main/CONTRIBUTING.md)
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is work in progress, mark it a draft on GitHub.
  4. Please write your PR title to summarize what this PR proposes, we 
    are following Conventional Commits style for PR titles as well.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

### What changes were proposed in this PR?
<!--
Please clarify what changes you are proposing. The purpose of this section 
is to outline the changes. Here are some tips for you:
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
  3. If it is a refactoring, clarify what has been changed.
  3. It would be helpful to include a before-and-after comparison using 
     screenshots or GIFs.
  4. Please consider writing useful notes for better and faster reviews.
-->
This PR integrates the MERFISHeyes visualization microservice into ADMAP, and adds a one-click launch button on the dataset detail page.

**Changes:**
helm:
- New `merfisheyes-deployment.yaml` / `merfisheyes-service.yaml` templates.                                                                            - `gateway-routes.yaml`: adds a conditional `PathPrefix: /merfisheyes` route when `merfisheyes.enabled` is true.                                       - `values.yaml`: adds a `merfisheyes` section, default `enabled: false` (no behavior change for existing deployments).                                
- `values-development.yaml`: enables `merfisheyes` for the dev profile, pointing to the public image

Frontend:                                                                                                                       
- Adds a visualization launch button next to the version selector.
- The button inspects the current dataset version's file tree and auto-selects the target:                                                       
    1. MERFISHeyes Single Cell (requires `manifest.json(.gz)` + `expr/`, `obs/`, `coords/`)                                                             
    2. MERFISHeyes Single Molecule (requires `manifest.json(.gz)` + `genes/`)                                                                           
    3. AAV Gallery (existing behavior, re-used)                                                                                                         
- Button is disabled with a tooltip when no compatible layout is detected.                                                                            
- Opens the selected viewer in a new tab with `owner`, `dataset`, `version`, and optional `datasetRoot` query params.

**Demo**

https://github.com/user-attachments/assets/41f92ad0-798e-4b5a-800b-b9a993530755

