### PR TITLE
feat(dataset): add card view for dataset list

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/DatasetSearchQueryBuilder.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/DatasetSearchQueryBuilder.scala
@@ -48,7 +48,9 @@ object DatasetSearchQueryBuilder extends SearchQueryBuilder with LazyLogging {
     repositoryName = DATASET.REPOSITORY_NAME,
     isDatasetPublic = DATASET.IS_PUBLIC,
     isDatasetDownloadable = DATASET.IS_DOWNLOADABLE,
-    datasetUserAccess = DATASET_USER_ACCESS.PRIVILEGE
+    datasetUserAccess = DATASET_USER_ACCESS.PRIVILEGE,
+    datasetCoverImage = DATASET.COVER_IMAGE,
+    datasetVisualizationType = DATASET.VISUALIZATION_TYPE
   )
 
   /*

--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/UnifiedResourceSchema.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/UnifiedResourceSchema.scala
@@ -72,7 +72,9 @@ object UnifiedResourceSchema {
       repositoryName: Field[String] = DSL.inline(""),
       isDatasetPublic: Field[java.lang.Boolean] = DSL.cast(null, classOf[java.lang.Boolean]),
       isDatasetDownloadable: Field[java.lang.Boolean] = DSL.cast(null, classOf[java.lang.Boolean]),
-      datasetUserAccess: Field[PrivilegeEnum] = DSL.castNull(classOf[PrivilegeEnum])
+      datasetUserAccess: Field[PrivilegeEnum] = DSL.castNull(classOf[PrivilegeEnum]),
+      datasetCoverImage: Field[String] = DSL.cast(null, classOf[String]),
+      datasetVisualizationType: Field[String] = DSL.cast(null, classOf[String])
   ): UnifiedResourceSchema = {
     new UnifiedResourceSchema(
       Seq(
@@ -96,7 +98,9 @@ object UnifiedResourceSchema {
         repositoryName -> repositoryName.as("repository_name"),
         isDatasetPublic -> isDatasetPublic.as("is_dataset_public"),
         isDatasetDownloadable -> isDatasetDownloadable.as("is_dataset_downloadable"),
-        datasetUserAccess -> datasetUserAccess.as("user_dataset_access")
+        datasetUserAccess -> datasetUserAccess.as("user_dataset_access"),
+        datasetCoverImage -> datasetCoverImage.as("cover_image"),
+        datasetVisualizationType -> datasetVisualizationType.as("visualization_type")
       )
     )
   }

--- a/frontend/src/app/dashboard/component/user/search-results/search-results.component.html
+++ b/frontend/src/app/dashboard/component/user/search-results/search-results.component.html
@@ -20,36 +20,59 @@
 <nz-card
   class="section-list-container"
   [nzBodyStyle]="{ height: '100%'}">
-  <!-- itemSize: the height (px) of each list item,
-        this MUST be approximately the same as list item size set in CSS,
-        .workflow-list-item sets the item size to be 70px, with additional paddings/margins it's approximately 80px
-      -->
-  <cdk-virtual-scroll-viewport
-    itemSize="70"
-    class="virtual-scroll-container">
-    <nz-list>
-      <ng-container *ngFor="let entry of entries">
-        <texera-list-item
-          (deleted)="deleted.emit(entry)"
-          (duplicated)="duplicated.emit(entry)"
-          (refresh)="refresh.emit()"
-          [isPrivateSearch]="isPrivateSearch"
-          [editable]="editable"
+  <!-- LIST VIEW -->
+  <ng-container *ngIf="viewMode === 'list'">
+    <cdk-virtual-scroll-viewport
+      itemSize="70"
+      class="virtual-scroll-container">
+      <nz-list>
+        <ng-container *ngFor="let entry of entries">
+          <texera-list-item
+            (deleted)="deleted.emit(entry)"
+            (duplicated)="duplicated.emit(entry)"
+            (refresh)="refresh.emit()"
+            [isPrivateSearch]="isPrivateSearch"
+            [editable]="editable"
+            [entry]="entry"
+            [currentUid]="this.currentUid"
+            (checkboxChanged)="onEntryCheckboxChange()">
+          </texera-list-item>
+        </ng-container>
+      </nz-list>
+      <div
+        nz-list-load-more
+        class="load-more">
+        <button
+          nz-button
+          *ngIf="!loading && more"
+          (click)="loadMore()">
+          Load more
+        </button>
+      </div>
+    </cdk-virtual-scroll-viewport>
+  </ng-container>
+
+  <!-- CARD VIEW (datasets only) -->
+  <ng-container *ngIf="viewMode === 'card'">
+    <div class="card-scroll-container">
+      <div class="card-grid">
+        <texera-dataset-card-item
+          *ngFor="let entry of entries; trackBy: trackByEntryId"
           [entry]="entry"
-          [currentUid]="this.currentUid"
-          (checkboxChanged)="onEntryCheckboxChange()">
-        </texera-list-item>
-      </ng-container>
-    </nz-list>
-    <div
-      nz-list-load-more
-      class="load-more">
-      <button
-        nz-button
-        *ngIf="!loading && more"
-        (click)="loadMore()">
-        Load more
-      </button>
+          [editable]="editable"
+          [currentUid]="currentUid"
+          (deleted)="deleted.emit(entry)"
+          (refresh)="refresh.emit()">
+        </texera-dataset-card-item>
+      </div>
+      <div class="load-more">
+        <button
+          nz-button
+          *ngIf="!loading && more"
+          (click)="loadMore()">
+          Load more
+        </button>
+      </div>
     </div>
-  </cdk-virtual-scroll-viewport>
+  </ng-container>
 </nz-card>

--- a/frontend/src/app/dashboard/component/user/search-results/search-results.component.scss
+++ b/frontend/src/app/dashboard/component/user/search-results/search-results.component.scss
@@ -27,6 +27,35 @@
   line-height: 32px;
 }
 
+.card-scroll-container {
+  height: 100%;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 16px;
+  align-items: stretch;
+
+  @media (max-width: 1280px) {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  @media (max-width: 1024px) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  @media (max-width: 768px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @media (max-width: 480px) {
+    grid-template-columns: 1fr;
+  }
+}
+
 nz-sider {
   background: rgb(255, 255, 255);
 }

--- a/frontend/src/app/dashboard/component/user/search-results/search-results.component.ts
+++ b/frontend/src/app/dashboard/component/user/search-results/search-results.component.ts
@@ -25,12 +25,14 @@ import { ɵɵCdkVirtualScrollViewport, ɵɵCdkFixedSizeVirtualScroll } from "@an
 import { NzListComponent } from "ng-zorro-antd/list";
 import { NgFor, NgIf } from "@angular/common";
 import { ListItemComponent } from "../list-item/list-item.component";
+import { UserDatasetCardItemComponent } from "../user-dataset/user-dataset-card-item/user-dataset-card-item.component";
 import { NzSpaceCompactItemDirective } from "ng-zorro-antd/space";
 import { NzButtonComponent } from "ng-zorro-antd/button";
 import { NzWaveDirective } from "ng-zorro-antd/core/wave";
 import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
 
 export type LoadMoreFunction = (start: number, count: number) => Promise<{ entries: DashboardEntry[]; more: boolean }>;
+export type SearchResultsViewMode = "list" | "card";
 
 @Component({
   selector: "texera-search-results",
@@ -43,6 +45,7 @@ export type LoadMoreFunction = (start: number, count: number) => Promise<{ entri
     NzListComponent,
     NgFor,
     ListItemComponent,
+    UserDatasetCardItemComponent,
     NgIf,
     NzSpaceCompactItemDirective,
     NzButtonComponent,
@@ -62,6 +65,7 @@ export class SearchResultsComponent {
   @Input() editable = false;
   @Input() searchKeywords: string[] = [];
   @Input() currentUid: number | undefined;
+  @Input() viewMode: SearchResultsViewMode = "list";
   @Output() deleted = new EventEmitter<DashboardEntry>();
   @Output() duplicated = new EventEmitter<DashboardEntry>();
   @Output() modified = new EventEmitter<DashboardEntry>();
@@ -112,4 +116,6 @@ export class SearchResultsComponent {
   clearAllSelections() {
     this.entries.forEach(entry => (entry.checked = false));
   }
+
+  trackByEntryId = (_: number, entry: DashboardEntry): string => `${entry.type}-${entry.id}`;
 }

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-card-item/user-dataset-card-item.component.html
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-card-item/user-dataset-card-item.component.html
@@ -1,0 +1,143 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+<nz-card
+  nzHoverable
+  class="dataset-card"
+  [nzCover]="coverTpl"
+  [routerLink]="entryLink">
+  <div class="dataset-card-body-link">
+    <div class="card-title-row">
+      <span
+        class="card-title"
+        [title]="entry.name">
+        {{ entry.name }}
+      </span>
+      <button
+        *ngIf="editable"
+        class="more-btn"
+        nz-dropdown
+        nzTrigger="click"
+        nzPlacement="bottomRight"
+        [nzDropdownMenu]="cardActionsMenu"
+        (click)="$event.stopPropagation(); $event.preventDefault()"
+        nz-tooltip="More actions">
+        <i
+          nz-icon
+          nzType="more"
+          nzTheme="outline"></i>
+      </button>
+    </div>
+
+    <div class="card-meta">
+      <div class="meta-line meta-line--owner">
+        <texera-user-avatar
+          class="meta-avatar"
+          [googleAvatar]="entry.ownerGoogleAvatar"
+          userColor="#1E90FF"
+          [userName]="entry.ownerName || entry.ownerEmail || 'User'"
+          [isOwner]="entry.ownerId === currentUid">
+        </texera-user-avatar>
+        <span
+          class="meta-owner-name truncate-single-line"
+          [title]="entry.ownerName || entry.ownerEmail">
+          {{ entry.ownerName || entry.ownerEmail || 'Unknown' }}
+        </span>
+        <span
+          class="meta-stat--like"
+          [class.liked]="isLiked"
+          [class.disabled]="!currentUid"
+          (click)="$event.stopPropagation(); $event.preventDefault(); currentUid && toggleLike()">
+          <i
+            nz-icon
+            nzType="heart"
+            [nzTheme]="isLiked ? 'fill' : 'outline'"></i>
+          {{ formatCount(likeCount) }}
+        </span>
+      </div>
+      <div class="meta-line meta-line--stats truncate-single-line">
+        <span>Updated {{ formatRelativeTime(entry.lastModifiedTime) }}</span>
+        <span class="meta-divider">·</span>
+        <span>{{ formatSize(entry.size) }}</span>
+        <span class="meta-divider">·</span>
+        <span>{{ formatCount(viewCount) }} views</span>
+      </div>
+    </div>
+  </div>
+</nz-card>
+
+<ng-template #coverTpl>
+  <div class="cover-container">
+    <img
+      class="cover-image"
+      [src]="coverImageSrc"
+      (error)="onCoverError($event)"
+      loading="lazy"
+      decoding="async"
+      alt="dataset cover" />
+    <span class="cover-id-badge">#{{ entry.id }}</span>
+    <span
+      *ngIf="visualizationLabel"
+      class="cover-viewer-badge"
+      [nz-tooltip]="visualizationLabelLong">
+      {{ visualizationLabel }}
+    </span>
+  </div>
+</ng-template>
+
+<nz-dropdown-menu #cardActionsMenu="nzDropdownMenu">
+  <ul
+    nz-menu
+    class="dataset-card-actions-menu">
+    <li
+      nz-menu-item
+      (click)="onClickOpenShareAccess()">
+      <i
+        nz-icon
+        nzType="share-alt"
+        nzTheme="outline"></i>
+      Share
+    </li>
+    <li
+      nz-menu-item
+      (click)="onClickDownload()">
+      <i
+        nz-icon
+        nzType="cloud-download"
+        nzTheme="outline"></i>
+      Download
+    </li>
+    <li
+      *ngIf="editable"
+      nz-menu-item
+      nzDanger
+      [nzDisabled]="!canDelete"
+      nz-popconfirm
+      nzPopconfirmTitle="Confirm to delete this dataset."
+      nzOkText="Delete"
+      nzOkDanger
+      (nzOnConfirm)="deleted.emit()">
+      <i
+        nz-icon
+        nzType="delete"
+        nzTheme="outline"></i>
+      Delete
+    </li>
+  </ul>
+</nz-dropdown-menu>

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-card-item/user-dataset-card-item.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-card-item/user-dataset-card-item.component.scss
@@ -1,0 +1,221 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+:host {
+  display: block;
+  height: 100%;
+  min-width: 0;
+}
+
+.dataset-card {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  cursor: pointer;
+}
+
+.dataset-card-body-link {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  color: inherit;
+}
+
+.cover-container {
+  position: relative;
+  height: 140px;
+  background: #f5f5f5;
+  overflow: hidden;
+
+  .cover-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  .cover-id-badge,
+  .cover-viewer-badge {
+    position: absolute;
+    font-size: 12px;
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+  }
+
+  .cover-id-badge {
+    left: 8px;
+    bottom: 8px;
+    padding: 2px 8px;
+    background: rgba(0, 0, 0, 0.55);
+    color: white;
+  }
+
+  .cover-viewer-badge {
+    right: 8px;
+    top: 8px;
+    padding: 3px 9px;
+    max-width: calc(100% - 60px);
+    background: rgba(255, 255, 255, 0.92);
+    color: #595959;
+    font-size: 11px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.card-title-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  margin-bottom: 12px;
+
+  .card-title {
+    flex: 1;
+    min-width: 0;
+    height: calc(15px * 1.35 * 2);
+    font-size: 15px;
+    font-weight: 600;
+    line-height: 1.35;
+    color: #222;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+    word-break: break-word;
+  }
+
+  .more-btn {
+    flex-shrink: 0;
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: #8c8c8c;
+    border-radius: 4px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    i {
+      font-size: 18px;
+    }
+
+    &:hover {
+      background: #f0f0f0;
+      color: #1f1f1f;
+    }
+  }
+}
+
+.truncate-single-line {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+::ng-deep .dataset-card-actions-menu.ant-dropdown-menu {
+  li.ant-dropdown-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 16px;
+
+    i {
+      font-size: 14px;
+    }
+  }
+}
+
+.card-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: auto;
+  padding-top: 12px;
+  border-top: 1px solid #f0f0f0;
+  min-width: 0;
+
+  .meta-line {
+    min-width: 0;
+
+    &--owner {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      color: #595959;
+
+      .meta-avatar {
+        flex-shrink: 0;
+
+        ::ng-deep nz-avatar.ant-avatar {
+          width: 20px;
+          height: 20px;
+          line-height: 20px;
+          font-size: 10px;
+        }
+        ::ng-deep .owner-badge {
+          font-size: 9px;
+        }
+      }
+
+      .meta-owner-name {
+        flex: 1;
+        min-width: 0;
+      }
+    }
+
+    &--stats {
+      font-size: 12px;
+      color: #8c8c8c;
+    }
+  }
+
+  .meta-divider {
+    color: #d9d9d9;
+    margin: 0 4px;
+  }
+
+  .meta-stat--like {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    cursor: pointer;
+
+    i {
+      font-size: 12px;
+    }
+
+    &.liked,
+    &:not(.disabled):hover {
+      color: #ff4d4f;
+    }
+
+    &.disabled {
+      cursor: default;
+    }
+  }
+}

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-card-item/user-dataset-card-item.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-card-item/user-dataset-card-item.component.spec.ts
@@ -1,0 +1,267 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { RouterTestingModule } from "@angular/router/testing";
+import { NzModalService } from "ng-zorro-antd/modal";
+import { of } from "rxjs";
+import type { Mocked } from "vitest";
+
+import { UserDatasetCardItemComponent } from "./user-dataset-card-item.component";
+import { DashboardEntry } from "src/app/dashboard/type/dashboard-entry";
+import { DatasetService } from "../../../../service/user/dataset/dataset.service";
+import { DownloadService } from "../../../../service/user/download/download.service";
+import { ActionType, HubService } from "../../../../../hub/service/hub.service";
+import { UserService } from "../../../../../common/service/user/user.service";
+import { StubUserService } from "../../../../../common/service/user/stub-user.service";
+import { AppSettings } from "../../../../../common/app-setting";
+import { DASHBOARD_HUB_DATASET_RESULT_DETAIL, DASHBOARD_USER_DATASET } from "../../../../../app-routing.constant";
+import { commonTestProviders } from "../../../../../common/testing/test-utils";
+
+function makeDatasetEntry(overrides: Partial<any> = {}): DashboardEntry {
+  return {
+    type: "dataset",
+    id: 42,
+    name: "Test Dataset",
+    description: "",
+    creationTime: Date.now() - 86400000,
+    lastModifiedTime: Date.now() - 3600000,
+    accessLevel: "WRITE",
+    ownerName: "Alice",
+    ownerEmail: "alice@example.com",
+    ownerGoogleAvatar: "",
+    ownerId: 1,
+    size: 2_621_440, // 2.5 MB
+    viewCount: 21,
+    likeCount: 5,
+    isLiked: false,
+    accessibleUserIds: [1, 2],
+    coverImageUrl: undefined,
+    dataset: {
+      isOwner: true,
+      ownerEmail: "alice@example.com",
+      accessPrivilege: "WRITE",
+      size: 2_621_440,
+      contributors: [],
+      dataset: {
+        did: 42,
+        ownerUid: 1,
+        name: "Test Dataset",
+        isPublic: true,
+        isDownloadable: true,
+        storagePath: "",
+        description: "",
+        creationTime: Date.now() - 86400000,
+        coverImage: undefined,
+        visualizationType: "none",
+      },
+    },
+    ...overrides,
+  } as unknown as DashboardEntry;
+}
+
+describe("UserDatasetCardItemComponent", () => {
+  let component: UserDatasetCardItemComponent;
+  let fixture: ComponentFixture<UserDatasetCardItemComponent>;
+  let hubService: Mocked<HubService>;
+
+  beforeEach(async () => {
+    const datasetServiceSpy = { retrieveOwners: vi.fn().mockReturnValue(of([])) };
+    const downloadServiceSpy = { downloadDataset: vi.fn().mockReturnValue(of(new Blob())) };
+    const hubServiceSpy = {
+      postLike: vi.fn().mockReturnValue(of(true)),
+      postUnlike: vi.fn().mockReturnValue(of(true)),
+      getCounts: vi.fn().mockReturnValue(of([{ counts: { like: 7 } }])),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [UserDatasetCardItemComponent, HttpClientTestingModule, BrowserAnimationsModule, RouterTestingModule],
+      providers: [
+        { provide: DatasetService, useValue: datasetServiceSpy },
+        { provide: DownloadService, useValue: downloadServiceSpy },
+        { provide: HubService, useValue: hubServiceSpy },
+        { provide: UserService, useClass: StubUserService },
+        NzModalService,
+        ...commonTestProviders,
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UserDatasetCardItemComponent);
+    component = fixture.componentInstance;
+    hubService = TestBed.inject(HubService) as unknown as Mocked<HubService>;
+  });
+
+  describe("visualizationLabel", () => {
+    it("returns short + long label for merfisheyes_single_cell", () => {
+      component.entry = makeDatasetEntry({
+        dataset: {
+          ...makeDatasetEntry().dataset,
+          dataset: { ...makeDatasetEntry().dataset.dataset, visualizationType: "merfisheyes_single_cell" },
+        },
+      });
+      component.ngOnChanges({ entry: { currentValue: component.entry } } as any);
+      expect(component.visualizationLabel).toBe("MERFISH viewer");
+      expect(component.visualizationLabelLong).toBe("MERFISHEYES Single Cell");
+    });
+
+    it("returns short + long label for aav_gallery", () => {
+      component.entry = makeDatasetEntry({
+        dataset: {
+          ...makeDatasetEntry().dataset,
+          dataset: { ...makeDatasetEntry().dataset.dataset, visualizationType: "aav_gallery" },
+        },
+      });
+      component.ngOnChanges({ entry: { currentValue: component.entry } } as any);
+      expect(component.visualizationLabel).toBe("Image gallery");
+      expect(component.visualizationLabelLong).toBe("AAV Gallery");
+    });
+
+    it("returns null when visualizationType is 'none'", () => {
+      component.entry = makeDatasetEntry();
+      component.ngOnChanges({ entry: { currentValue: component.entry } } as any);
+      expect(component.visualizationLabel).toBeNull();
+      expect(component.visualizationLabelLong).toBeNull();
+    });
+
+    it("returns null when visualizationType is undefined", () => {
+      const entry = makeDatasetEntry();
+      (entry as any).dataset.dataset.visualizationType = undefined;
+      component.entry = entry;
+      component.ngOnChanges({ entry: { currentValue: entry } } as any);
+      expect(component.visualizationLabel).toBeNull();
+    });
+  });
+
+  describe("entryLink", () => {
+    it("routes to user dataset page when currentUid is in accessibleUserIds", () => {
+      component.currentUid = 1;
+      component.entry = makeDatasetEntry({ id: 99, accessibleUserIds: [1, 2] });
+      component.ngOnChanges({ entry: { currentValue: component.entry } } as any);
+      expect(component.entryLink).toEqual([DASHBOARD_USER_DATASET, "99"]);
+    });
+
+    it("routes to hub detail page when currentUid is not in accessibleUserIds", () => {
+      component.currentUid = 5;
+      component.entry = makeDatasetEntry({ id: 99, accessibleUserIds: [1, 2] });
+      component.ngOnChanges({ entry: { currentValue: component.entry } } as any);
+      expect(component.entryLink).toEqual([DASHBOARD_HUB_DATASET_RESULT_DETAIL, "99"]);
+    });
+
+    it("routes to hub detail page when currentUid is undefined", () => {
+      component.currentUid = undefined;
+      component.entry = makeDatasetEntry({ id: 99, accessibleUserIds: [1, 2] });
+      component.ngOnChanges({ entry: { currentValue: component.entry } } as any);
+      expect(component.entryLink).toEqual([DASHBOARD_HUB_DATASET_RESULT_DETAIL, "99"]);
+    });
+  });
+
+  describe("coverImageSrc", () => {
+    it("uses default cover when coverImageUrl is undefined", () => {
+      component.entry = makeDatasetEntry({ coverImageUrl: undefined });
+      component.ngOnChanges({ entry: { currentValue: component.entry } } as any);
+      expect(component.coverImageSrc).toBe(component.defaultCover);
+    });
+
+    it("builds API URL when coverImageUrl is set", () => {
+      component.entry = makeDatasetEntry({ id: 7, coverImageUrl: "v1/img.png" });
+      component.ngOnChanges({ entry: { currentValue: component.entry } } as any);
+      expect(component.coverImageSrc).toBe(`${AppSettings.getApiEndpoint()}/dataset/7/cover`);
+    });
+  });
+
+  describe("formatCount", () => {
+    it("renders raw count under 1000", () => {
+      expect(component.formatCount(0)).toBe("0");
+      expect(component.formatCount(999)).toBe("999");
+    });
+
+    it("abbreviates thousands as Xk", () => {
+      expect(component.formatCount(1000)).toBe("1.0k");
+      expect(component.formatCount(2500)).toBe("2.5k");
+      expect(component.formatCount(15234)).toBe("15.2k");
+    });
+  });
+
+  describe("formatRelativeTime", () => {
+    const NOW = 1_700_000_000_000;
+    beforeEach(() => vi.setSystemTime(NOW));
+    afterEach(() => vi.useRealTimers());
+
+    it("formats minutes", () => {
+      expect(component.formatRelativeTime(NOW - 30 * 60_000)).toBe("30m ago");
+    });
+
+    it("formats hours", () => {
+      expect(component.formatRelativeTime(NOW - 5 * 3600_000)).toBe("5h ago");
+    });
+
+    it("formats days", () => {
+      expect(component.formatRelativeTime(NOW - 3 * 86400_000)).toBe("3d ago");
+    });
+
+    it("formats weeks", () => {
+      expect(component.formatRelativeTime(NOW - 2 * 7 * 86400_000)).toBe("2w ago");
+    });
+
+    it("falls back to absolute date past 4 weeks", () => {
+      const result = component.formatRelativeTime(NOW - 60 * 86400_000);
+      expect(result).not.toMatch(/ago$/);
+    });
+
+    it("returns 'Unknown' for undefined", () => {
+      expect(component.formatRelativeTime(undefined)).toBe("Unknown");
+    });
+  });
+
+  describe("toggleLike", () => {
+    beforeEach(() => {
+      component.currentUid = 1;
+      component.entry = makeDatasetEntry();
+      component.ngOnChanges({ entry: { currentValue: component.entry } } as any);
+    });
+
+    it("does nothing when user is not logged in", () => {
+      component.currentUid = undefined;
+      component.toggleLike();
+      expect(hubService.postLike).not.toHaveBeenCalled();
+      expect(hubService.postUnlike).not.toHaveBeenCalled();
+    });
+
+    it("calls postLike and updates isLiked when not liked", () => {
+      component.isLiked = false;
+      component.toggleLike();
+      expect(hubService.postLike).toHaveBeenCalledWith(42, "dataset");
+      expect(component.isLiked).toBe(true);
+      expect(hubService.getCounts).toHaveBeenCalledWith(["dataset"], [42], [ActionType.Like]);
+      expect(component.likeCount).toBe(7);
+    });
+
+    it("calls postUnlike and updates isLiked when already liked", () => {
+      component.isLiked = true;
+      component.toggleLike();
+      expect(hubService.postUnlike).toHaveBeenCalledWith(42, "dataset");
+      expect(component.isLiked).toBe(false);
+      expect(component.likeCount).toBe(7);
+    });
+  });
+});

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-card-item/user-dataset-card-item.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-card-item/user-dataset-card-item.component.ts
@@ -1,0 +1,242 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges,
+} from "@angular/core";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { NgIf } from "@angular/common";
+import { RouterLink } from "@angular/router";
+import { NzCardComponent } from "ng-zorro-antd/card";
+import { NzIconDirective } from "ng-zorro-antd/icon";
+import { NzButtonComponent } from "ng-zorro-antd/button";
+import { NzWaveDirective } from "ng-zorro-antd/core/wave";
+import { NzPopconfirmDirective } from "ng-zorro-antd/popconfirm";
+import { NzTooltipModule } from "ng-zorro-antd/tooltip";
+import { NzDropdownDirective, NzDropdownMenuComponent } from "ng-zorro-antd/dropdown";
+import { NzMenuDirective, NzMenuItemComponent } from "ng-zorro-antd/menu";
+import { firstValueFrom } from "rxjs";
+import { DashboardEntry } from "../../../../type/dashboard-entry";
+import { UserAvatarComponent } from "../../user-avatar/user-avatar.component";
+import { ShareAccessComponent } from "../../share-access/share-access.component";
+import { DatasetService } from "../../../../service/user/dataset/dataset.service";
+import { DownloadService } from "../../../../service/user/download/download.service";
+import { ActionType, HubService } from "../../../../../hub/service/hub.service";
+import { NzModalRef, NzModalService } from "ng-zorro-antd/modal";
+import { AppSettings } from "../../../../../common/app-setting";
+import { formatSize } from "../../../../../common/util/size-formatter.util";
+import { isDefined } from "../../../../../common/util/predicate";
+import { DASHBOARD_HUB_DATASET_RESULT_DETAIL, DASHBOARD_USER_DATASET } from "../../../../../app-routing.constant";
+
+@UntilDestroy()
+@Component({
+  selector: "texera-dataset-card-item",
+  templateUrl: "./user-dataset-card-item.component.html",
+  styleUrls: ["./user-dataset-card-item.component.scss"],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    NgIf,
+    RouterLink,
+    NzCardComponent,
+    NzIconDirective,
+    NzButtonComponent,
+    NzWaveDirective,
+    NzPopconfirmDirective,
+    NzTooltipModule,
+    NzDropdownDirective,
+    NzDropdownMenuComponent,
+    NzMenuDirective,
+    NzMenuItemComponent,
+    UserAvatarComponent,
+  ],
+})
+export class UserDatasetCardItemComponent implements OnChanges {
+  @Input() editable = false;
+  @Input() currentUid: number | undefined;
+  @Output() deleted = new EventEmitter<void>();
+  @Output() refresh = new EventEmitter<void>();
+
+  private _entry?: DashboardEntry;
+  @Input()
+  get entry(): DashboardEntry {
+    if (!this._entry) {
+      throw new Error("entry property must be provided.");
+    }
+    return this._entry;
+  }
+  set entry(value: DashboardEntry) {
+    this._entry = value;
+  }
+
+  entryLink: string[] = [];
+  coverImageSrc: string = "";
+  readonly defaultCover = "../../../../../../assets/card_background.jpg";
+  likeCount = 0;
+  viewCount = 0;
+  isLiked = false;
+
+  constructor(
+    private modalService: NzModalService,
+    private datasetService: DatasetService,
+    private downloadService: DownloadService,
+    private hubService: HubService,
+    private cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes["entry"]) {
+      this.initializeEntry();
+      this.likeCount = this.entry.likeCount ?? 0;
+      this.viewCount = this.entry.viewCount ?? 0;
+      this.isLiked = this.entry.isLiked ?? false;
+    }
+  }
+
+  private initializeEntry(): void {
+    if (this.entry.type !== "dataset" || typeof this.entry.id !== "number") {
+      return;
+    }
+    const owners = this.entry.accessibleUserIds;
+    if (this.currentUid !== undefined && owners.includes(this.currentUid)) {
+      this.entryLink = [DASHBOARD_USER_DATASET, String(this.entry.id)];
+    } else {
+      this.entryLink = [DASHBOARD_HUB_DATASET_RESULT_DETAIL, String(this.entry.id)];
+    }
+    this.coverImageSrc = this.entry.coverImageUrl
+      ? `${AppSettings.getApiEndpoint()}/dataset/${this.entry.id}/cover`
+      : this.defaultCover;
+  }
+
+  onCoverError(event: Event): void {
+    (event.target as HTMLImageElement).src = this.defaultCover;
+  }
+
+  public async onClickOpenShareAccess(): Promise<void> {
+    const modal: NzModalRef<ShareAccessComponent> = this.modalService.create({
+      nzContent: ShareAccessComponent,
+      nzData: {
+        writeAccess: this.entry.accessLevel === "WRITE",
+        type: "dataset",
+        id: this.entry.id,
+        allOwners: await firstValueFrom(this.datasetService.retrieveOwners()),
+      },
+      nzFooter: null,
+      nzTitle: "Share this dataset with others",
+      nzCentered: true,
+      nzWidth: "700px",
+    });
+    modal.componentInstance?.refresh.pipe(untilDestroyed(this)).subscribe(() => this.refresh.emit());
+  }
+
+  public onClickDownload = (): void => {
+    if (!this.entry.id) return;
+    this.downloadService.downloadDataset(this.entry.id, this.entry.name).pipe(untilDestroyed(this)).subscribe();
+  };
+
+  toggleLike(): void {
+    if (!isDefined(this.currentUid) || !isDefined(this.entry.id)) return;
+    const entryId = this.entry.id;
+    const refreshCount = () => {
+      this.hubService
+        .getCounts([this.entry.type], [entryId], [ActionType.Like])
+        .pipe(untilDestroyed(this))
+        .subscribe(counts => {
+          this.likeCount = counts[0]?.counts.like ?? 0;
+          this.cdr.markForCheck();
+        });
+    };
+
+    if (this.isLiked) {
+      this.hubService
+        .postUnlike(entryId, this.entry.type)
+        .pipe(untilDestroyed(this))
+        .subscribe(success => {
+          if (success) {
+            this.isLiked = false;
+            this.cdr.markForCheck();
+            refreshCount();
+          }
+        });
+    } else {
+      this.hubService
+        .postLike(entryId, this.entry.type)
+        .pipe(untilDestroyed(this))
+        .subscribe(success => {
+          if (success) {
+            this.isLiked = true;
+            this.cdr.markForCheck();
+            refreshCount();
+          }
+        });
+    }
+  }
+
+  get canDelete(): boolean {
+    return this.entry.type === "dataset" && this.entry.dataset.isOwner;
+  }
+
+  private static readonly VISUALIZATION_LABELS: Record<string, { short: string; long: string }> = {
+    merfisheyes_single_cell: { short: "MERFISH viewer", long: "MERFISHEYES Single Cell" },
+    merfisheyes_single_molecule: { short: "MERFISH viewer", long: "MERFISHEYES Single Molecule" },
+    aav_gallery: { short: "Image gallery", long: "AAV Gallery" },
+  };
+
+  private get visualizationLabels(): { short: string; long: string } | null {
+    if (this.entry.type !== "dataset") return null;
+    const type = this.entry.dataset.dataset.visualizationType;
+    if (!type || type === "none") return null;
+    return UserDatasetCardItemComponent.VISUALIZATION_LABELS[type] ?? { short: type, long: type };
+  }
+
+  get visualizationLabel(): string | null {
+    return this.visualizationLabels?.short ?? null;
+  }
+
+  get visualizationLabelLong(): string | null {
+    return this.visualizationLabels?.long ?? null;
+  }
+
+  formatSize = formatSize;
+
+  formatCount(count: number): string {
+    if (count >= 1000) return (count / 1000).toFixed(1) + "k";
+    return String(count);
+  }
+
+  formatRelativeTime(timestamp: number | undefined): string {
+    if (timestamp === undefined) return "Unknown";
+    const diff = Date.now() - timestamp;
+    const m = Math.floor(diff / 60000);
+    const h = Math.floor(diff / 3600000);
+    const d = Math.floor(diff / 86400000);
+    const w = Math.floor(d / 7);
+    if (m < 60) return `${m}m ago`;
+    if (h < 24) return `${h}h ago`;
+    if (d < 7) return `${d}d ago`;
+    if (w < 4) return `${w}w ago`;
+    return new Date(timestamp).toLocaleDateString();
+  }
+}

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.html
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.html
@@ -33,6 +33,32 @@
         <span>Create Dataset</span>
       </button>
       <texera-filters #filters></texera-filters>
+      <div class="view-toggle">
+        <button
+          nz-button
+          nzType="text"
+          [class.active]="viewMode === 'list'"
+          (click)="setViewMode('list')"
+          nz-tooltip="List view"
+          title="List view">
+          <i
+            nz-icon
+            nzType="bars"
+            nzTheme="outline"></i>
+        </button>
+        <button
+          nz-button
+          nzType="text"
+          [class.active]="viewMode === 'card'"
+          (click)="setViewMode('card')"
+          nz-tooltip="Card view"
+          title="Card view">
+          <i
+            nz-icon
+            nzType="picture"
+            nzTheme="outline"></i>
+        </button>
+      </div>
     </div>
   </nz-card>
 
@@ -55,6 +81,7 @@
   <texera-search-results
     [editable]="true"
     [isPrivateSearch]="true"
+    [viewMode]="viewMode"
     (deleted)="deleteDataset($event)"
     (refresh)="ngAfterViewInit()"
     [currentUid]="currentUid"></texera-search-results>

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.scss
@@ -25,3 +25,35 @@
   height: 55px;
   overflow-y: hidden;
 }
+
+.view-toggle {
+  display: inline-flex;
+  background: #f5f5f5;
+  border-radius: 6px;
+  padding: 2px;
+  margin-left: 8px;
+
+  button {
+    height: 28px;
+    padding: 0 10px;
+    border: none;
+    background: transparent;
+    color: #8c8c8c;
+    border-radius: 4px;
+    box-shadow: none;
+    transition:
+      background 0.15s ease,
+      color 0.15s ease;
+
+    &:hover {
+      color: #595959;
+      background: rgba(255, 255, 255, 0.6);
+    }
+
+    &.active {
+      background: #fff;
+      color: #1f1f1f;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
+  }
+}

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.ts
@@ -35,14 +35,16 @@ import { DashboardDataset } from "../../../type/dashboard-dataset.interface";
 import { NzMessageService } from "ng-zorro-antd/message";
 import { map, tap } from "rxjs/operators";
 import { NzCardComponent } from "ng-zorro-antd/card";
-import { NzSpaceCompactItemDirective } from "ng-zorro-antd/space";
 import { NzButtonComponent } from "ng-zorro-antd/button";
 import { NzWaveDirective } from "ng-zorro-antd/core/wave";
 import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
 import { NzIconDirective } from "ng-zorro-antd/icon";
+import { NzTooltipModule } from "ng-zorro-antd/tooltip";
 import { FiltersInstructionsComponent } from "../filters-instructions/filters-instructions.component";
 import { NzSelectComponent } from "ng-zorro-antd/select";
 import { FormsModule } from "@angular/forms";
+
+export const DATASET_VIEW_MODE_STORAGE_KEY = "texera.dataset.viewMode";
 
 @UntilDestroy()
 @Component({
@@ -51,11 +53,11 @@ import { FormsModule } from "@angular/forms";
   styleUrls: ["user-dataset.component.scss"],
   imports: [
     NzCardComponent,
-    NzSpaceCompactItemDirective,
     NzButtonComponent,
     NzWaveDirective,
     ɵNzTransitionPatchDirective,
     NzIconDirective,
+    NzTooltipModule,
     FiltersComponent,
     FiltersInstructionsComponent,
     NzSelectComponent,
@@ -69,6 +71,13 @@ export class UserDatasetComponent implements AfterViewInit {
   public isLogin = this.userService.isLogin();
   public currentUid = this.userService.getCurrentUser()?.uid;
   public hasMismatch = false; // Display warning when there are mismatched datasets
+  public viewMode: "list" | "card" = (localStorage.getItem(DATASET_VIEW_MODE_STORAGE_KEY) as "list" | "card") || "list";
+
+  setViewMode(mode: "list" | "card"): void {
+    if (this.viewMode === mode) return;
+    this.viewMode = mode;
+    localStorage.setItem(DATASET_VIEW_MODE_STORAGE_KEY, mode);
+  }
 
   private _searchResultsComponent?: SearchResultsComponent;
   @ViewChild(SearchResultsComponent) get searchResultsComponent(): SearchResultsComponent {

--- a/frontend/src/app/hub/component/hub-search-result/hub-search-result.component.html
+++ b/frontend/src/app/hub/component/hub-search-result/hub-search-result.component.html
@@ -23,12 +23,41 @@
       <texera-sort-button (sortMethodChange)="sortMethod = $event; search()"></texera-sort-button>
       <texera-filters #filters></texera-filters>
     </div>
+    <div
+      *ngIf="searchType === 'dataset'"
+      class="view-toggle view-toggle--right">
+      <button
+        nz-button
+        nzType="text"
+        [class.active]="viewMode === 'list'"
+        (click)="setViewMode('list')"
+        nz-tooltip="List view"
+        title="List view">
+        <i
+          nz-icon
+          nzType="bars"
+          nzTheme="outline"></i>
+      </button>
+      <button
+        nz-button
+        nzType="text"
+        [class.active]="viewMode === 'card'"
+        (click)="setViewMode('card')"
+        nz-tooltip="Card view"
+        title="Card view">
+        <i
+          nz-icon
+          nzType="picture"
+          nzTheme="outline"></i>
+      </button>
+    </div>
   </div>
 
   <div class="search-result">
     <texera-search-results
       [showResourceTypes]="true"
       [searchKeywords]="searchKeywords"
+      [viewMode]="searchType === 'dataset' ? viewMode : 'list'"
       [currentUid]="this.currentUid">
     </texera-search-results>
   </div>

--- a/frontend/src/app/hub/component/hub-search-result/hub-search-result.component.scss
+++ b/frontend/src/app/hub/component/hub-search-result/hub-search-result.component.scss
@@ -18,3 +18,39 @@
  */
 
 @import "../../../dashboard/component/user/search/search.component";
+
+.view-toggle {
+  display: inline-flex;
+  background: #f5f5f5;
+  border-radius: 6px;
+  padding: 2px;
+  margin-left: 8px;
+
+  &--right {
+    margin-left: auto;
+  }
+
+  button {
+    height: 28px;
+    padding: 0 10px;
+    border: none;
+    background: transparent;
+    color: #8c8c8c;
+    border-radius: 4px;
+    box-shadow: none;
+    transition:
+      background 0.15s ease,
+      color 0.15s ease;
+
+    &:hover {
+      color: #595959;
+      background: rgba(255, 255, 255, 0.6);
+    }
+
+    &.active {
+      background: #fff;
+      color: #1f1f1f;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
+  }
+}

--- a/frontend/src/app/hub/component/hub-search-result/hub-search-result.component.ts
+++ b/frontend/src/app/hub/component/hub-search-result/hub-search-result.component.ts
@@ -29,18 +29,41 @@ import { isDefined } from "../../../common/util/predicate";
 import { firstValueFrom } from "rxjs";
 import { map } from "rxjs/operators";
 import { SortButtonComponent } from "../../../dashboard/component/user/sort-button/sort-button.component";
+import { NgIf } from "@angular/common";
+import { NzButtonComponent } from "ng-zorro-antd/button";
+import { NzIconDirective } from "ng-zorro-antd/icon";
+import { NzTooltipModule } from "ng-zorro-antd/tooltip";
+import { NzWaveDirective } from "ng-zorro-antd/core/wave";
+import { DATASET_VIEW_MODE_STORAGE_KEY } from "../../../dashboard/component/user/user-dataset/user-dataset.component";
 
 @UntilDestroy()
 @Component({
   selector: "texera-hub-search",
   templateUrl: "./hub-search-result.component.html",
   styleUrls: ["./hub-search-result.component.scss"],
-  imports: [SortButtonComponent, FiltersComponent, SearchResultsComponent],
+  imports: [
+    SortButtonComponent,
+    FiltersComponent,
+    SearchResultsComponent,
+    NgIf,
+    NzButtonComponent,
+    NzIconDirective,
+    NzTooltipModule,
+    NzWaveDirective,
+  ],
 })
 export class HubSearchResultComponent implements OnInit, AfterViewInit {
   public searchType: "dataset" | "workflow" = "workflow";
   public searchKeywords: string[] = [];
   currentUid = this.userService.getCurrentUser()?.uid;
+
+  public viewMode: "list" | "card" = (localStorage.getItem(DATASET_VIEW_MODE_STORAGE_KEY) as "list" | "card") || "list";
+
+  setViewMode(mode: "list" | "card"): void {
+    if (this.viewMode === mode) return;
+    this.viewMode = mode;
+    localStorage.setItem(DATASET_VIEW_MODE_STORAGE_KEY, mode);
+  }
 
   private isLogin = false;
   private includePublic = true;


### PR DESCRIPTION
<!--
Thanks for sending a pull request (PR)! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 
     [Contributing to Texera](https://github.com/apache/texera/blob/main/CONTRIBUTING.md)
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is work in progress, mark it a draft on GitHub.
  4. Please write your PR title to summarize what this PR proposes, we 
    are following Conventional Commits style for PR titles as well.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

### What changes were proposed in this PR?
<!--
Please clarify what changes you are proposing. The purpose of this section 
is to outline the changes. Here are some tips for you:
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
  3. If it is a refactoring, clarify what has been changed.
  3. It would be helpful to include a before-and-after comparison using 
     screenshots or GIFs.
  4. Please consider writing useful notes for better and faster reviews.
-->
This PR adds a card view mode for dataset listings on both the Hub/public dataset page and the private/user dataset page. Users can switch between the existing list view and the new card view using a view toggle in the page header.

**Changes:**
- Frontend
  - New `texera-dataset-card-item` component: cover image, title (2-line clamp), available visualizer, owner row (avatar + name + like button), stats row (updated time/size/views), viewer badge overlay on cover, "..." dropdown for Share/Download/Delete (private side only)
  - `SearchResultsComponent`: added `viewMode: 'list'|'card'` input, card mode renders a CSS grid (5 cols on desktop, responsive down to 1 col).
  - `UserDatasetComponent` & `HubSearchResultComponent`: list/card toggle in the header, preference persisted to localStorage (`texera.dataset.viewMode`), shared across both pages
  - `OnPush` change detection + lazy image loading on cards for performance

- Backend
  - `UnifiedResourceSchema` / `DatasetSearchQueryBuilder`: include `cover_image` and `visualization_type` in dataset search results so cards can render covers and viewer chips without extra round-trips

### Demos
Private dataset list

<img width="1555" height="535" alt="Private dataset card view" src="https://github.com/user-attachments/assets/b656387e-4a23-4090-b918-797755be2fda" />

Public dataset list

<img width="1568" height="752" alt="Public dataset card view" src="https://github.com/user-attachments/assets/54713ad2-1750-44c8-8202-f8655e0a017d" />

### How was this PR tested?
<!--
If tests were added, say they were added here. Or simply mention that if the PR 
is tested with existing test cases.  Make sure to include/update test cases that
check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how
you tested step by step, ideally copy and paste-able, so that other reviewers can
test and check, and descendants can verify in the future. If tests were not added, 
please describe why they were not added and/or why it was difficult to add. 
-->
Added 20 new tests and manually tested.

### Was this PR authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this PR, 
please include the phrase: 'Generated-by: ' followed by the name of the tool 
and its version. If no, write 'No'. 
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Opus 4.7

### TODO
- [ ] Add Download and Share actions to public dataset cards.
- [ ] Further polish the card layout and metadata display.