### PR TITLE
fix: permit anonymous access to public file redirect endpoint

### DIFF
--- a/file-service/src/main/scala/org/apache/texera/service/resource/DatasetResource.scala
+++ b/file-service/src/main/scala/org/apache/texera/service/resource/DatasetResource.scala
@@ -2381,6 +2381,7 @@ class DatasetResource extends LazyLogging {
   }
 
   @GET
+  @PermitAll
   @Path("/public-file")
   def getPublicFileRedirect(
       @QueryParam("filePath") encodedUrl: String,

--- a/file-service/src/test/scala/org/apache/texera/service/resource/DatasetResourcePermissionsSpec.scala
+++ b/file-service/src/test/scala/org/apache/texera/service/resource/DatasetResourcePermissionsSpec.scala
@@ -54,7 +54,8 @@ class DatasetResourcePermissionsSpec extends AnyFlatSpec with Matchers {
     "retrievePublicDatasetVersionRootFileNodes",
     "getPublicDataset",
     "getDatasetCover",
-    "getDatasetCoverUrl"
+    "getDatasetCoverUrl",
+    "getPublicFileRedirect"
   )
 
   "DatasetResource" should "expose HTTP endpoints (sanity check for the reflection scan)" in {


### PR DESCRIPTION
### What changes were proposed in this PR?
This PR makes two changes:

- Add `@PermitAll` to `getPublicFileRedirect` in `DatasetResource.scala`
- Add `"getPublicFileRedirect"` to `publicEndpointMethods` in `DatasetResourcePermissionsSpec.scala`

Anonymous access is safe here: the endpoint enforces its own dataset-level check via `resolveDatasetAndPath(..., uid = null)` → `userHasReadAccess(ctx, did, null)`, which throws `ForbiddenException` unless the dataset is public — the owner/privilege branches can never match a null uid. It also exposes nothing new: it shares the exact code path with `getPublicPresignedUrl` (already `@PermitAll`) and merely returns the same presigned URL as a 307 redirect, so `<img src>` can load public-dataset files without an Authorization header. The `isDownloadable` restriction is unaffected — it is enforced per-endpoint on `/{did}/versionZip`, which remains login-only.

### Any related issues, documentation, discussions?

N/A

### How was this PR tested?

Existing test suite: `sbt "FileService/testOnly org.apache.texera.service.resource.DatasetResourcePermissionsSpec"` — 4/4 passed. The spec's reflection scan is exactly the check that fails without this change (`getPublicFileRedirect` has neither `@PermitAll` nor `@RolesAllowed`).

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Fable 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)