### PR TITLE
feat: add reconstruction & cell-detection Python deps to operator-requirements

### DIFF
--- a/amber/operator-requirements.txt
+++ b/amber/operator-requirements.txt
@@ -29,3 +29,16 @@ torch==2.8.0 ; platform_system != "Linux" or platform_machine != "x86_64"
 scikit-learn==1.5.0
 transformers==5.0.0rc3
 scikit-image==0.25.2
+
+# Volumetric image reconstruction + cell detection operators.
+# opencv MUST be the -headless build (image has no display; the regular
+# opencv-python fails to import without libGL). zarr/ome-zarr/dask are
+# pinned as a mutually compatible group on the zarr 3.x line; versions
+# resolved against the pinned numpy==2.1.0 in requirements.txt.
+SimpleITK==2.4.0
+opencv-python-headless==4.10.0.84
+zarr==3.2.1
+dask==2026.7.1
+ome-zarr==0.18.0
+natsort==8.4.0
+six==1.17.0


### PR DESCRIPTION
### What changes were proposed in this PR?

Adds 7 Python packages to `amber/operator-requirements.txt` for the volumetric image **reconstruction (Step 1–4)** and **cell-detection** operators:

| Package | Version | Notes |
|---|---|---|
| SimpleITK | 2.4.0 | |
| opencv-python-headless | 4.10.0.84 | **headless** build — the runtime image has no display server; the regular `opencv-python` fails to import without `libGL` |
| zarr | 3.2.1 | zarr 3.x line |
| dask | 2026.7.1 | |
| ome-zarr | 0.18.0 | supports zarr 3 |
| natsort | 8.4.0 | |
| six | 1.17.0 | |

They are added to `amber/operator-requirements.txt` (the operator/UDF dependency file), **not** hardcoded into the Dockerfile: both the master and worker runtime images already run `pip install -r operator-requirements.txt`, so this file stays the single source of version pins.

`numpy` / `pandas` / `scipy` / `scikit-image` / `joblib` are already present (directly or transitively) and are not duplicated. Registration is out of scope for now, so `nibabel` / `open3d` / `tqdm` / elastix are intentionally left out.

### Any related issues, documentation, discussions?

N/A.

### How was this PR tested?

No automated tests were added (this change only pins runtime dependencies). Versions were resolved and verified manually:

1. Created a clean venv and installed the 7 packages with the existing pins as constraints, so `numpy==2.1.0` (from `requirements.txt`) was held fixed:
   ```
   pip install -c constraints.txt \
     "SimpleITK==2.4.0" "opencv-python-headless==4.10.0.84" \
     "zarr>=3.0" "dask" "ome-zarr" "natsort==8.4.0" "six==1.17.0"
   ```
2. The resolver produced a mutually compatible set (zarr 3.2.1 / ome-zarr 0.18.0 / dask 2026.7.1) with numpy still at 2.1.0.
3. Import-verified every package:
   ```
   import SimpleITK, cv2, zarr, dask, ome_zarr, natsort, six, numpy
   assert numpy.__version__ == "2.1.0"
   ```
   All imported successfully and the numpy pin held.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Fable 5)