### PR TITLE
fix: pin brain-imaging UDF deps to Python 3.10-compatible versions

### DIFF
--- a/amber/operator-requirements.txt
+++ b/amber/operator-requirements.txt
@@ -35,10 +35,10 @@ scikit-image==0.25.2
 # opencv-python fails to import without libGL). zarr/ome-zarr/dask are
 # pinned as a mutually compatible group on the zarr 3.x line; versions
 # resolved against the pinned numpy==2.1.0 in requirements.txt.
-SimpleITK==2.4.0
-opencv-python-headless==4.10.0.84
-zarr==3.2.1
+SimpleITK==2.5.5
+opencv-python-headless==5.0.0.93
+zarr==2.17.2
 dask==2026.7.1
-ome-zarr==0.18.0
+ome-zarr==0.11.1
 natsort==8.4.0
 six==1.17.0


### PR DESCRIPTION
#90 pinned zarr/ome-zarr on the 3.x line, which requires Python >=3.11
(zarr 3.2+ needs 3.12) and fails to install on the CU image (jammy,
Python 3.10). This pins them to 3.10-compatible versions:

| package                 | before      | after     |
|-------------------------|-------------|-----------|
| zarr                    | 3.2.1       | 2.17.2    |
| ome-zarr                | 0.18.0      | 0.11.1    |
| SimpleITK               | 2.4.0       | 2.5.5     |
| opencv-python-headless  | 4.10.0.84   | 5.0.0.93  |

Validated on Python 3.10. No Python bump, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)