### PR TITLE
fix(agent-service): authenticate compile requests to the compiling se…

### DIFF
--- a/agent-service/src/agent/texera-agent.ts
+++ b/agent-service/src/agent/texera-agent.ts
@@ -539,10 +539,11 @@ export class TexeraAgent {
         stopWhen: stepCountIs(this.settings.maxSteps),
         prepareStep: async ({ stepNumber, messages: currentMessages }) => {
           let compilationResult: WorkflowCompilationResponse | null = null;
-          if (this.workflowState.getAllOperators().length > 0) {
+          const compileToken = this.delegateConfig?.userToken;
+          if (compileToken && this.workflowState.getAllOperators().length > 0) {
             try {
               const logicalPlan = this.workflowState.toLogicalPlan();
-              compilationResult = await compileWorkflowAsync(logicalPlan);
+              compilationResult = await compileWorkflowAsync(logicalPlan, compileToken);
             } catch (e: any) {
               this.log.warn({ err: e?.message || e }, "compilation failed; proceeding without schemas");
             }

--- a/agent-service/src/api/compile-api.ts
+++ b/agent-service/src/api/compile-api.ts
@@ -18,6 +18,7 @@
  */
 
 import { getBackendConfig } from "./backend-api";
+import { createAuthHeaders } from "./auth-api";
 import type { LogicalPlan, OperatorPortSchemaMap } from "../types/workflow";
 import { createLogger } from "../logger";
 
@@ -42,7 +43,10 @@ export interface WorkflowCompilationResponse {
   operatorErrors: Record<string, WorkflowFatalError>;
 }
 
-export async function compileWorkflowAsync(logicalPlan: LogicalPlan): Promise<WorkflowCompilationResponse | null> {
+export async function compileWorkflowAsync(
+  logicalPlan: LogicalPlan,
+  token: string
+): Promise<WorkflowCompilationResponse | null> {
   const config = getBackendConfig();
   const url = `${config.compileEndpoint}/api/compile`;
 
@@ -56,7 +60,7 @@ export async function compileWorkflowAsync(logicalPlan: LogicalPlan): Promise<Wo
   try {
     const response = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: createAuthHeaders(token),
       body: JSON.stringify(body),
     });
 


### PR DESCRIPTION
…rvice

`compileWorkflowAsync` sent only a Content-Type header, so every call to the workflow-compiling-service `/api/compile` endpoint came back 401.

That endpoint is annotated `@RolesAllowed(Array("REGULAR", "ADMIN"))`, and since #5404 made `JwtAuthFilter` eager-401 with a `@PermitAll` opt-out, a request with no `Authorization: Bearer` header is rejected before it reaches the resource. The agent calls the compiling service directly (service-to-service, not through the gateway), so nothing injected the header on its behalf.

The compile failure is caught and logged, so the agent degraded silently: it ran every step with no operator output schemas instead of failing loudly.

Thread the delegating user's token through, matching how `workflow-api` already authenticates via `createAuthHeaders`. When no delegate token is present the compile call is skipped rather than issued unauthenticated, since it could only 401.


Claude-Session: https://claude.ai/code/session_01AtAUakDV4TkGJdrAPhxXwL

<!--
Thanks for sending a pull request (PR)! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 
     [Contributing to Texera](https://github.com/apache/texera/blob/main/CONTRIBUTING.md)
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is work in progress, mark it a draft on GitHub.
  4. Please write your PR title to summarize what this PR proposes, we 
    are following Conventional Commits style for PR titles as well.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

### What changes were proposed in this PR?
<!--
Please clarify what changes you are proposing. The purpose of this section 
is to outline the changes. Here are some tips for you:
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
  3. If it is a refactoring, clarify what has been changed.
  3. It would be helpful to include a before-and-after comparison using 
     screenshots or GIFs.
  4. Please consider writing useful notes for better and faster reviews.
-->


### Any related issues, documentation, discussions?
<!--
Please use this section to link other resources if not mentioned already.
  1. If this PR fixes an issue, please include `Fixes #1234`, `Resolves #1234`
     or `Closes #1234`. If it is only related, simply mention the issue number.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->


### How was this PR tested?
<!--
If tests were added, say they were added here. Or simply mention that if the PR 
is tested with existing test cases.  Make sure to include/update test cases that
check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how
you tested step by step, ideally copy and paste-able, so that other reviewers can
test and check, and descendants can verify in the future. If tests were not added, 
please describe why they were not added and/or why it was difficult to add. 
-->


### Was this PR authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this PR, 
please include the phrase: 'Generated-by: ' followed by the name of the tool 
and its version. If no, write 'No'. 
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
